### PR TITLE
feat(macos): add configurable system menus

### DIFF
--- a/modules/window/macos/ffi.mbt
+++ b/modules/window/macos/ffi.mbt
@@ -99,6 +99,23 @@ extern "C" fn appkit_notification_center_remove_observer(
 ///|
 #borrow(call_closure)
 #owned(callback)
+extern "C" fn native_install_menu_action_callback(
+  call_closure : FuncRef[((Int) -> Unit, Int) -> Unit],
+  callback : (Int) -> Unit,
+) -> Unit = "mbw_install_menu_action_callback"
+
+///|
+extern "C" fn native_create_menu_action_target() -> UInt64 = "mbw_create_menu_action_target"
+
+///|
+extern "C" fn native_set_menu_item_action_id(
+  item_handle : UInt64,
+  action_id : Int,
+) -> Unit = "mbw_set_menu_item_action_id"
+
+///|
+#borrow(call_closure)
+#owned(callback)
 extern "C" fn native_main_run_loop_add_observer(
   call_closure : FuncRef[((Int) -> Unit, Int) -> Unit],
   callback : (Int) -> Unit,

--- a/modules/window/macos/menu.mbt
+++ b/modules/window/macos/menu.mbt
@@ -374,3 +374,225 @@ fn initialize_default_menu(enabled : Bool) -> Unit {
   }
   native_application_initialize_default_menu(enabled)
 }
+
+///|
+/// A single item in a custom system menu. For separator items, set
+/// `separator = true`; all other fields are ignored.
+pub struct SystemMenuItemDescriptor {
+  title : String
+  action_id : Int
+  key_equivalent : String
+  key_modifier_mask : Int
+  separator : Bool
+} derive(Debug)
+
+///|
+pub fn SystemMenuItemDescriptor::new(
+  title~ : String,
+  action_id~ : Int,
+  key_equivalent~ : String,
+  key_modifier_mask~ : Int,
+  separator~ : Bool,
+) -> SystemMenuItemDescriptor {
+  { title, action_id, key_equivalent, key_modifier_mask, separator }
+}
+
+///|
+/// A top-level custom system menu, such as File, Edit, or View.
+pub struct SystemMenuDescriptor {
+  title : String
+  items : Array[SystemMenuItemDescriptor]
+} derive(Debug)
+
+///|
+pub fn SystemMenuDescriptor::new(
+  title~ : String,
+  items~ : Array[SystemMenuItemDescriptor],
+) -> SystemMenuDescriptor {
+  { title, items }
+}
+
+///|
+/// Keeps the registered native callback alive for the lifetime of the process.
+let menu_action_callback_ref : Ref[((Int) -> Unit)?] = Ref(None)
+
+///|
+/// Registers the callback invoked when a custom system menu item is selected.
+/// The callback receives that item's `action_id`.
+pub fn set_system_menu_action_handler(handler : (Int) -> Unit) -> Unit {
+  menu_action_callback_ref.val = Some(handler)
+  native_install_menu_action_callback(
+    fn(callback, action_id) { callback(action_id) },
+    handler,
+  )
+}
+
+///|
+/// Builds and installs a native macOS system menu bar from `menus`.
+///
+/// The standard application menu (About, Services, Hide, and Quit) remains
+/// available. Register an action handler with `set_system_menu_action_handler`
+/// before installing menus that contain actionable items.
+pub fn set_system_menus(menus : Array[SystemMenuDescriptor]) -> Unit {
+  let app = native_application_shared_handle()
+  if app == (0 : Int).to_uint64() {
+    return ()
+  }
+
+  let main_menu = native_appkit_new_menu("")
+  if native_objc_owned_valid(main_menu) == false {
+    return ()
+  }
+  let app_menu_item = native_appkit_new_menu_item(
+    "",
+    "",
+    "",
+    (0 : Int).to_uint64(),
+    -1,
+  )
+  let app_menu = native_appkit_new_menu("")
+  if native_objc_owned_valid(app_menu_item) {
+    native_appkit_add_menu_item(main_menu, app_menu_item)
+    if native_objc_owned_valid(app_menu) {
+      appkit_objc_msg_send_void_u64(
+        native_objc_owned_handle(app_menu_item),
+        objc_runtime_selector_handle("setSubmenu:"),
+        native_objc_owned_handle(app_menu),
+      )
+    }
+  }
+  if native_objc_owned_valid(app_menu) {
+    let about_item = native_appkit_new_menu_item(
+      "About", "orderFrontStandardAboutPanel:", "", app, -1,
+    )
+    if native_objc_owned_valid(about_item) {
+      native_appkit_add_menu_item(app_menu, about_item)
+      appkit_objc_release_object(about_item)
+    }
+    native_appkit_add_separator_item(app_menu)
+    let services_item = native_appkit_new_menu_item(
+      "Services",
+      "",
+      "",
+      (0 : Int).to_uint64(),
+      -1,
+    )
+    let services_menu = native_appkit_new_menu("Services")
+    if native_objc_owned_valid(services_menu) {
+      appkit_objc_msg_send_void_u64(
+        app,
+        objc_runtime_selector_handle("setServicesMenu:"),
+        native_objc_owned_handle(services_menu),
+      )
+      if native_objc_owned_valid(services_item) {
+        appkit_objc_msg_send_void_u64(
+          native_objc_owned_handle(services_item),
+          objc_runtime_selector_handle("setSubmenu:"),
+          native_objc_owned_handle(services_menu),
+        )
+      }
+      appkit_objc_release_object(services_menu)
+    }
+    if native_objc_owned_valid(services_item) {
+      native_appkit_add_menu_item(app_menu, services_item)
+      appkit_objc_release_object(services_item)
+    }
+    let hide_item = native_appkit_new_menu_item("Hide", "hide:", "h", app, -1)
+    if native_objc_owned_valid(hide_item) {
+      native_appkit_add_menu_item(app_menu, hide_item)
+      appkit_objc_release_object(hide_item)
+    }
+    let option_cmd = 524288 + 1_048_576
+    let hide_others = native_appkit_new_menu_item(
+      "Hide Others", "hideOtherApplications:", "h", app, option_cmd,
+    )
+    if native_objc_owned_valid(hide_others) {
+      native_appkit_add_menu_item(app_menu, hide_others)
+      appkit_objc_release_object(hide_others)
+    }
+    let show_all = native_appkit_new_menu_item(
+      "Show All", "unhideAllApplications:", "", app, -1,
+    )
+    if native_objc_owned_valid(show_all) {
+      native_appkit_add_menu_item(app_menu, show_all)
+      appkit_objc_release_object(show_all)
+    }
+    native_appkit_add_separator_item(app_menu)
+    let quit_item = native_appkit_new_menu_item(
+      "Quit", "terminate:", "q", app, -1,
+    )
+    if native_objc_owned_valid(quit_item) {
+      native_appkit_add_menu_item(app_menu, quit_item)
+      appkit_objc_release_object(quit_item)
+    }
+  }
+
+  let target = native_create_menu_action_target()
+  for menu_desc in menus {
+    let menu_item_obj = native_appkit_new_menu_item(
+      "",
+      "",
+      "",
+      (0 : Int).to_uint64(),
+      -1,
+    )
+    let submenu = native_appkit_new_menu(menu_desc.title)
+    if native_objc_owned_valid(menu_item_obj) {
+      native_appkit_add_menu_item(main_menu, menu_item_obj)
+      if native_objc_owned_valid(submenu) {
+        appkit_objc_msg_send_void_u64(
+          native_objc_owned_handle(menu_item_obj),
+          objc_runtime_selector_handle("setSubmenu:"),
+          native_objc_owned_handle(submenu),
+        )
+      }
+    }
+    if native_objc_owned_valid(submenu) {
+      for item_desc in menu_desc.items {
+        if item_desc.separator {
+          native_appkit_add_separator_item(submenu)
+        } else {
+          let key_modifier_mask = if item_desc.key_modifier_mask >= 0 {
+            item_desc.key_modifier_mask
+          } else {
+            -1
+          }
+          let item = native_appkit_new_menu_item(
+            item_desc.title,
+            "handleMenuAction:",
+            item_desc.key_equivalent,
+            target,
+            key_modifier_mask,
+          )
+          if native_objc_owned_valid(item) {
+            native_set_menu_item_action_id(
+              native_objc_owned_handle(item),
+              item_desc.action_id,
+            )
+            native_appkit_add_menu_item(submenu, item)
+            appkit_objc_release_object(item)
+          }
+        }
+      }
+    }
+    if native_objc_owned_valid(submenu) {
+      appkit_objc_release_object(submenu)
+    }
+    if native_objc_owned_valid(menu_item_obj) {
+      appkit_objc_release_object(menu_item_obj)
+    }
+  }
+
+  appkit_objc_msg_send_void_u64(
+    app,
+    objc_runtime_selector_handle("setMainMenu:"),
+    native_objc_owned_handle(main_menu),
+  )
+  if native_objc_owned_valid(app_menu) {
+    appkit_objc_release_object(app_menu)
+  }
+  if native_objc_owned_valid(app_menu_item) {
+    appkit_objc_release_object(app_menu_item)
+  }
+  appkit_objc_release_object(main_menu)
+}

--- a/modules/window/macos/menu_wbtest.mbt
+++ b/modules/window/macos/menu_wbtest.mbt
@@ -1,0 +1,29 @@
+///|
+test "system menu descriptors retain item details" {
+  let open = SystemMenuItemDescriptor::new(
+    title="Open",
+    action_id=7,
+    key_equivalent="o",
+    key_modifier_mask=1_048_576,
+    separator=false,
+  )
+  let separator = SystemMenuItemDescriptor::new(
+    title="",
+    action_id=0,
+    key_equivalent="",
+    key_modifier_mask=-1,
+    separator=true,
+  )
+  let file_menu = SystemMenuDescriptor::new(title="File", items=[
+    open, separator,
+  ])
+
+  assert_eq(file_menu.title, "File")
+  assert_eq(file_menu.items.length(), 2)
+  assert_eq(file_menu.items[0].title, "Open")
+  assert_eq(file_menu.items[0].action_id, 7)
+  assert_eq(file_menu.items[0].key_equivalent, "o")
+  assert_eq(file_menu.items[0].key_modifier_mask, 1_048_576)
+  assert_false(file_menu.items[0].separator)
+  assert_true(file_menu.items[1].separator)
+}

--- a/modules/window/macos/moon.pkg
+++ b/modules/window/macos/moon.pkg
@@ -13,6 +13,7 @@ options(
     "native_monitor_appkit.m",
     "native_appkit_main_thread.m",
     "native_appkit_callbacks.m",
+    "native_appkit_menu.m",
     "native_appkit_observers.m",
     "native_appkit_window.m",
     "native_appkit.m",

--- a/modules/window/macos/native_appkit_bridge.h
+++ b/modules/window/macos/native_appkit_bridge.h
@@ -33,6 +33,7 @@ typedef void (*mbw_drag_event_trampoline_t)(void *closure, int32_t raw_id, int32
                                             uint64_t path_cstr);
 typedef int32_t (*mbw_sync_query_trampoline_t)(void *closure, int32_t raw_id, int32_t kind,
                                                uint64_t arg0);
+typedef void (*mbw_menu_action_trampoline_t)(void *closure, int32_t action_id);
 typedef void (*mbw_lifecycle_trampoline_t)(void *closure, int32_t kind);
 typedef void (*mbw_send_event_impl_t)(id self, SEL _cmd, NSEvent *event);
 typedef struct MBWObjcOwnedObjectHandle MBWObjcOwnedObjectHandle;

--- a/modules/window/macos/native_appkit_menu.m
+++ b/modules/window/macos/native_appkit_menu.m
@@ -1,0 +1,52 @@
+// System menu bar support for macOS.
+
+#import "native_appkit_bridge.h"
+#import <objc/runtime.h>
+
+static mbw_menu_action_trampoline_t g_menu_action_trampoline = NULL;
+static void *g_menu_action_closure = NULL;
+static id g_menu_action_target = nil;
+static const char kMBWMenuActionIdKey;
+
+@interface MBWMenuActionTarget : NSObject
+- (void)handleMenuAction:(id)sender;
+@end
+
+@implementation MBWMenuActionTarget
+
+- (void)handleMenuAction:(id)sender {
+  if (g_menu_action_trampoline == NULL || g_menu_action_closure == NULL) {
+    return;
+  }
+  NSNumber *action_id = objc_getAssociatedObject(sender, &kMBWMenuActionIdKey);
+  void *closure = g_menu_action_closure;
+  moonbit_incref(closure);
+  g_menu_action_trampoline(closure, action_id ? [action_id intValue] : -1);
+  moonbit_decref(closure);
+}
+
+@end
+
+MOONBIT_FFI_EXPORT
+void mbw_install_menu_action_callback(mbw_menu_action_trampoline_t trampoline, void *closure) {
+  if (g_menu_action_closure != NULL) {
+    moonbit_decref(g_menu_action_closure);
+  }
+  g_menu_action_trampoline = trampoline;
+  g_menu_action_closure = closure;
+}
+
+MOONBIT_FFI_EXPORT
+uint64_t mbw_create_menu_action_target(void) {
+  if (g_menu_action_target == nil) {
+    g_menu_action_target = [[MBWMenuActionTarget alloc] init];
+  }
+  return (uint64_t)(uintptr_t)g_menu_action_target;
+}
+
+MOONBIT_FFI_EXPORT
+void mbw_set_menu_item_action_id(uint64_t item_handle, int32_t action_id) {
+  id item = (__bridge id)(void *)item_handle;
+  objc_setAssociatedObject(item, &kMBWMenuActionIdKey,
+                           @(action_id), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}

--- a/modules/window/macos/pkg.generated.mbti
+++ b/modules/window/macos/pkg.generated.mbti
@@ -11,6 +11,10 @@ import {
 // Values
 pub fn monitor_ns_screen(@core.MonitorHandle) -> NSScreenHandle?
 
+pub fn set_system_menu_action_handler((Int) -> Unit) -> Unit
+
+pub fn set_system_menus(Array[SystemMenuDescriptor]) -> Unit
+
 // Errors
 
 // Types and methods
@@ -136,6 +140,21 @@ type NativeDisplayMode
 type NativeWindow
 
 type NotificationObserver
+
+pub struct SystemMenuDescriptor {
+  title : String
+  items : Array[SystemMenuItemDescriptor]
+} derive(@debug.Debug)
+pub fn SystemMenuDescriptor::new(title~ : String, items~ : Array[SystemMenuItemDescriptor]) -> Self
+
+pub struct SystemMenuItemDescriptor {
+  title : String
+  action_id : Int
+  key_equivalent : String
+  key_modifier_mask : Int
+  separator : Bool
+} derive(@debug.Debug)
+pub fn SystemMenuItemDescriptor::new(title~ : String, action_id~ : Int, key_equivalent~ : String, key_modifier_mask~ : Int, separator~ : Bool) -> Self
 
 pub struct Window {
   // private fields


### PR DESCRIPTION
## Summary
- add public descriptors for top-level menus and menu items
- dispatch native AppKit menu actions to a MoonBit callback by action ID
- preserve the standard application menu and cover descriptor construction

## Testing
- `moon -C modules/window check macos --target native --warn-list +73`
- `moon -C modules/window test macos --target native --release`
- `moon -C modules/window info --target native`